### PR TITLE
Add Laravel version selector and format results

### DIFF
--- a/laravel.php
+++ b/laravel.php
@@ -39,7 +39,15 @@ if (empty($results)) {
     exit;
 }
 
+$hits = [];
 foreach ($results as $hit) {
+    $url = "https://laravel.com/docs/{$branch}/{$hit['link']}";
+    if (in_array($url, $hits)) {
+        // Already included this URL
+        continue;
+    }
+    $hits[] = $url;
+
     $hasText = isset($hit['_highlightResult']['content']['value']);
     $hasSubtitle = isset($hit['h2']);
 
@@ -64,8 +72,8 @@ foreach ($results as $hit) {
         ->title($title)
         ->autocomplete($title)
         ->subtitle($subtitle)
-        ->arg("https://laravel.com/docs/{$branch}/{$hit['link']}")
-        ->quicklookurl("https://laravel.com/docs/{$branch}/{$hit['link']}")
+        ->arg($url)
+        ->quicklookurl($url)
         ->valid(true);
 }
 

--- a/laravel.php
+++ b/laravel.php
@@ -52,7 +52,7 @@ foreach ($results as $hit) {
     $hasSubtitle = isset($hit['h2']);
 
     $title = $hit['h1'];
-    $subtitle = $hasSubtitle ? $hit['h2'] : null;
+    $subtitle = $hit['h2'] . (! is_null($hit['h3']) ? " | " . $hit['h3'] : null) . (! is_null($hit['h4']) ? " » " . $hit['h4'] : null);
 
     if ($hasText) {
         $subtitle = $hit['_highlightResult']['content']['value'];

--- a/laravel.php
+++ b/laravel.php
@@ -8,7 +8,13 @@ use AlgoliaSearch\Version as AlgoliaUserAgent;
 require __DIR__ . '/vendor/autoload.php';
 
 $query = $argv[1];
-$branch = empty($_ENV['branch']) ? 'master' : $_ENV['branch'];
+preg_match('/^\s*?v?(master|(?:[\d]+)(?:\.[\d]+)?(?:\.[\d]+)?)?\s*?(.*?)$/', $query, $matches);
+if (trim($matches[1]) != "") {
+    $branch = $matches[1];
+    $query = $matches[2];
+} else {
+    $branch = empty($_ENV['branch']) ? 'master' : $_ENV['branch'];
+}
 
 $workflow = new Workflow;
 $parsedown = new Parsedown;


### PR DESCRIPTION
Thanks a ton for this workflow!

### Overview

This PR adds a few things:
- An optional Laravel version at the beginning of the input (e.g. `ld 5.1 helpers str`) that replaces `branch`
- Formatting the results to only return unique URL results and show all available subheadings (h2,h3,h4)

The formatting won't fix #2 for minimal themes, but you might just permanently move `h2` to the title and leave `h3` and `h4` for the subtitle.

### Screenshots

##### Subtitles for context
<img width="559" alt="monosnap 2018-07-31 09-58-33" src="https://user-images.githubusercontent.com/43112/43468728-5223acaa-94aa-11e8-9609-221d9a2c459a.png">


##### Laravel version
<img width="559" alt="monosnap 2018-07-31 09-38-27" src="https://user-images.githubusercontent.com/43112/43468775-6974b318-94aa-11e8-90f5-ae0279e34adb.png">

