### PR TITLE
Add Laravel version switch parameter

### DIFF
--- a/laravel.php
+++ b/laravel.php
@@ -11,7 +11,7 @@ $query = $argv[1];
 
 preg_match('/^\h*?v?(master|(?:[\d]+)(?:\.[\d]+)?(?:\.[\d]+)?)?\h*?(.*?)$/', $query, $matches);
 
-if (trim($matches[1]) != "") {
+if (empty(trim($matches[1]))) {
     $branch = $matches[1];
     $query = $matches[2];
 } else {

--- a/laravel.php
+++ b/laravel.php
@@ -8,7 +8,7 @@ use AlgoliaSearch\Version as AlgoliaUserAgent;
 require __DIR__ . '/vendor/autoload.php';
 
 $query = $argv[1];
-preg_match('/^\s*?v?(master|(?:[\d]+)(?:\.[\d]+)?(?:\.[\d]+)?)?\s*?(.*?)$/', $query, $matches);
+preg_match('/^\h*?v?(master|(?:[\d]+)(?:\.[\d]+)?(?:\.[\d]+)?)?\h*?(.*?)$/', $query, $matches);
 if (trim($matches[1]) != "") {
     $branch = $matches[1];
     $query = $matches[2];

--- a/laravel.php
+++ b/laravel.php
@@ -11,7 +11,7 @@ $query = $argv[1];
 
 preg_match('/^\h*?v?(master|(?:[\d]+)(?:\.[\d]+)?(?:\.[\d]+)?)?\h*?(.*?)$/', $query, $matches);
 
-if (empty(trim($matches[1]))) {
+if (! empty(trim($matches[1]))) {
     $branch = $matches[1];
     $query = $matches[2];
 } else {

--- a/laravel.php
+++ b/laravel.php
@@ -8,13 +8,16 @@ use AlgoliaSearch\Version as AlgoliaUserAgent;
 require __DIR__ . '/vendor/autoload.php';
 
 $query = $argv[1];
+
 preg_match('/^\h*?v?(master|(?:[\d]+)(?:\.[\d]+)?(?:\.[\d]+)?)?\h*?(.*?)$/', $query, $matches);
+
 if (trim($matches[1]) != "") {
     $branch = $matches[1];
     $query = $matches[2];
 } else {
     $branch = empty($_ENV['branch']) ? 'master' : $_ENV['branch'];
 }
+
 $subtext = empty($_ENV['alfred_theme_subtext']) ? '0' : $_ENV['alfred_theme_subtext'];
 
 $workflow = new Workflow;

--- a/laravel.php
+++ b/laravel.php
@@ -8,7 +8,13 @@ use AlgoliaSearch\Version as AlgoliaUserAgent;
 require __DIR__ . '/vendor/autoload.php';
 
 $query = $argv[1];
-$branch = empty($_ENV['branch']) ? 'master' : $_ENV['branch'];
+preg_match('/^\s*?v?(master|(?:[\d]+)(?:\.[\d]+)?(?:\.[\d]+)?)?\s*?(.*?)$/', $query, $matches);
+if (trim($matches[1]) != "") {
+    $branch = $matches[1];
+    $query = $matches[2];
+} else {
+    $branch = empty($_ENV['branch']) ? 'master' : $_ENV['branch'];
+}
 $subtext = empty($_ENV['alfred_theme_subtext']) ? '0' : $_ENV['alfred_theme_subtext'];
 
 $workflow = new Workflow;


### PR DESCRIPTION
I've already used this so many times in the last few days, thanks for publishing it.

### Overview

This PR adds an optional version switch in the command. If not included, the branch will fall back to the `$_ENV` value (defaults to `master` as before). This is a stripped down version of PR #3 since you're a rockstar who had already done half of the stuff 🥇 

Example to search docs for Laravel 5.1:

<img width="559" alt="monosnap 2018-07-31 10-09-12" src="https://user-images.githubusercontent.com/43112/43594107-01e4d034-963f-11e8-9a61-82720f61a5a2.png">
