### PR TITLE
Fix bug in Alfred 4 using getenv()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laravel Docs Workflow for Alfred
 
-An ultra-fast Laravel docs search workflow for [Alfred 3 & 4](https://www.alfredapp.com).
+An ultra-fast Laravel docs search workflow for [Alfred 3+](https://www.alfredapp.com).
 
 ![Screenshot](screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laravel Docs Workflow for Alfred
 
-An ultra-fast Laravel docs search workflow for [Alfred 3](https://www.alfredapp.com).
+An ultra-fast Laravel docs search workflow for [Alfred 3 & 4](https://www.alfredapp.com).
 
 ![Screenshot](screenshot.png)
 

--- a/laravel.php
+++ b/laravel.php
@@ -15,14 +15,14 @@ if (! empty(trim($matches[1]))) {
     $branch = $matches[1];
     $query = $matches[2];
 } else {
-    $branch = $_ENV['branch'];
+    $branch = getenv('branch');
 }
 
 if ($branch === 'latest') {
     $branch = null;
 }
 
-$subtext = empty($_ENV['alfred_theme_subtext']) ? '0' : $_ENV['alfred_theme_subtext'];
+$subtext = empty(getenv('alfred_theme_subtext')) ? '0' : getenv('alfred_theme_subtext');
 
 $workflow = new Workflow;
 $parsedown = new Parsedown;

--- a/laravel.php
+++ b/laravel.php
@@ -22,7 +22,11 @@ if ($branch === 'latest') {
     $branch = null;
 }
 
-$subtext = empty(getenv('alfred_theme_subtext')) ? '0' : getenv('alfred_theme_subtext');
+$subtext = getenv('alfred_theme_subtext');
+
+if (empty($subtext)) {
+    $subtext = '0';
+}
 
 $workflow = new Workflow;
 $parsedown = new Parsedown;


### PR DESCRIPTION
After doing a fresh install of Alfred 4 then downloading this workflow today it wasn't working correctly - the `ld` keyword was fine but any query would cause Alfred to default to performing a web search.

After using the debugging tool in Alfred I could see the following:

`PHP Notice: Undefined index: branch in [...]/laravel.php on line 18`

I also noticed the URL for the Laravel documentation was missing the branch variable in the JSON response.

After a quick search I came across [this](https://www.alfredforum.com/topic/9070-how-to-workflowenvironment-variables/) and [this](https://www.alfredforum.com/topic/9070-how-to-workflowenvironment-variables/?tab=comments#comment-46151) in the Alfred forums, stating in PHP we should use `getenv()` over `$_ENV`. After updating the code I found it is working perfectly in Alfred 4.