### PR TITLE
Allow number-only version filtering

### DIFF
--- a/laravel.php
+++ b/laravel.php
@@ -9,17 +9,20 @@ require __DIR__ . '/vendor/autoload.php';
 
 $query = $argv[1];
 
-preg_match('/^\h*?v?(master|(?:[\d]+)(?:\.[\d]+)?(?:\.[\d]+)?)?\h*?(.*?)$/', $query, $matches);
+preg_match('/^\h*?v?(master|(?:[\d]+)(?:\.[\d]+)?(?:\.[\dx]+)?)?\h*?(.*?)$/', $query, $matches);
 
 if (! empty(trim($matches[1]))) {
     $branch = $matches[1];
-    $query = $matches[2];
+    $query = trim($matches[2]);
 } else {
     $branch = getenv('branch');
 }
 
 if ($branch === 'latest') {
     $branch = null;
+} elseif (is_numeric($branch) && $branch > 5) {
+    // Format branch as docs URLs expect with .x suffix
+    $branch = "{$branch}.x";
 }
 
 $subtext = getenv('alfred_theme_subtext');


### PR DESCRIPTION
## Overview

This PR updates the `preg_match` expression to support version constraints without having to explicitly specify the `.x` suffix. This allows for simple version numbers (versions 6 and above) such as `6.x` or simply `6`.

This also fixes a bug when trying to specify using versions 6, 7, or 8 (in any format). Those now have the `.x` suffix appended to make Algolia filters happy.

Here's an overview of how the updated regex matches a number of potential inputs: https://regex101.com/r/h04PXl/1

|&nbsp;|Before|After|
|:-----:|:-----:|:-----:|
|`ld 6 collect`|<img width="605" alt="Screen Shot 2021-02-08 at 3 16 22 PM" src="https://user-images.githubusercontent.com/43112/107282642-e0538600-6a20-11eb-93bd-5271fb270dfc.png">|<img width="605" alt="Screen Shot 2021-02-08 at 3 14 57 PM" src="https://user-images.githubusercontent.com/43112/107282667-e9dcee00-6a20-11eb-8a31-220a5e7ea038.png">|
|`ld 6.x collect`|<img width="605" alt="Screen Shot 2021-02-08 at 3 16 32 PM" src="https://user-images.githubusercontent.com/43112/107282701-f5301980-6a20-11eb-8889-267262853657.png">|<img width="605" alt="Screen Shot 2021-02-08 at 3 14 48 PM" src="https://user-images.githubusercontent.com/43112/107282720-fcefbe00-6a20-11eb-98ca-a5e86cbba636.png">|

## Detailed Changes

* Update regex for inputs to match `#.x` version filters
* Add version formatting when number-only versions are provided, to add `.x` suffix
* Trim query before sending to search API