### PR TITLE
Fix error: $text not defined.

### DIFF
--- a/laravel.php
+++ b/laravel.php
@@ -87,6 +87,7 @@ foreach ($results as $hit) {
         $title = "{$title} » {$subtitle}";
     }
 
+    $text = '';
     if ($subtextSupported) {
         $text = $subtitle;
 


### PR DESCRIPTION
If $subtextSupported is false, then $text is not defined, throwing an error later on.