### PR TITLE
bump dependencies to fix 8.4 deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "license": "MIT",
     "require": {
-        "joetannenbaum/alfred-workflow": "^0.1.0",
-        "algolia/algoliasearch-client-php": "^3.0"
+        "joetannenbaum/alfred-workflow": "^0.1.3",
+        "algolia/algoliasearch-client-php": "^3.4.2"
     }
 }


### PR DESCRIPTION
this fixes 8.4 usage (enforcing latest patch versions)

herd compability is already in main, so we just need a new release after this merge

fixes #29 