### PR TITLE
Upgrade Algolia client to v4 for PHP 8.5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     },
     "license": "MIT",
     "require": {
+        "php": ">=8.1",
         "joetannenbaum/alfred-workflow": "^0.1.3",
         "algolia/algoliasearch-client-php": "^4.43"
     }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
     "license": "MIT",
     "require": {
         "joetannenbaum/alfred-workflow": "^0.1.3",
-        "algolia/algoliasearch-client-php": "^3.4.2"
+        "algolia/algoliasearch-client-php": "^4.43"
     }
 }

--- a/laravel.php
+++ b/laravel.php
@@ -2,8 +2,7 @@
 
 use Alfred\Workflows\Workflow;
 
-use Algolia\AlgoliaSearch\SearchClient;
-use Algolia\AlgoliaSearch\Support\UserAgent;
+use Algolia\AlgoliaSearch\Api\SearchClient;
 
 require __DIR__ . '/vendor/autoload.php';
 
@@ -34,12 +33,10 @@ if (empty($subtext)) {
 $workflow = new Workflow;
 $algolia = SearchClient::create('E3MIRNPJH5', '1fa3a8fec06eb1858d6ca137211225c0');
 
-UserAgent::addCustomUserAgent('Alfred Workflow', '0.4.0');
-
-$index = $algolia->initIndex('laravel');
-$search = $index->search($query, ['facetFilters' => [
-    sprintf('version:%s', $branch ?: 'master'),
-]]);
+$search = $algolia->searchSingleIndex('laravel', [
+    'query' => $query,
+    'facetFilters' => [sprintf('version:%s', $branch ?: 'master')],
+]);
 
 $results = $search['hits'];
 $subtextSupported = $subtext === '0' || $subtext === '2';

--- a/laravel.php
+++ b/laravel.php
@@ -35,7 +35,9 @@ $algolia = SearchClient::create('E3MIRNPJH5', '1fa3a8fec06eb1858d6ca137211225c0'
 
 $search = $algolia->searchSingleIndex('laravel', [
     'query' => $query,
-    'facetFilters' => [sprintf('version:%s', $branch ?: 'master')],
+    'facetFilters' => [
+        sprintf('version:%s', $branch ?: 'master')
+    ],
 ]);
 
 $results = $search['hits'];


### PR DESCRIPTION
## Upgrade Algolia client to v4 for PHP 8.5 support

### Why

On PHP 8.5, the v3 Algolia client calls `curl_close()`, which is now
[deprecated](https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_curl_close_curl_multi_close_and_curl_share_close).
With `display_errors` on (the default in many setups), the deprecation
notice is written to stdout — the same stream Alfred parses as JSON —
breaking the workflow.

The v4 client requires PHP `>=8.1 !=8.3.0` and is emit-clean on 8.5.

### Changes

- `composer.json`: bump `algolia/algoliasearch-client-php` from `^3.4.2` to `^4.43`.
- `laravel.php`:
  - Update import from `Algolia\AlgoliaSearch\SearchClient` to `Algolia\AlgoliaSearch\Api\SearchClient`.
  - Collapse `initIndex('laravel')->search($query, [...])` into the single `searchSingleIndex('laravel', ['query' => $query, ...])` call (v4 removes the index handle).
  - Drop the `UserAgent::addCustomUserAgent()` call — that helper no longer exists in v4 (the SDK appends its own identifier).

The response shape is unchanged (`hits` array with `hierarchy`, `url`,
`_highlightResult`, `objectID` keys), so the result-building code is
untouched.

### Testing

Tested on PHP 8.5.5 (Herd) with `php laravel.php "validation"`:
- stdout: clean JSON, 20 hits
- stderr: 0 bytes
